### PR TITLE
Automatically detect the correct NodeJS binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Docker Compose >= 1.11
 - OpenSSL >= 1.0.0
 - Python >= 2.7 or >=3.4
+- NodeJS >= 4.0
 
 ## Installation
 

--- a/scripts/gen-token-auth-cert
+++ b/scripts/gen-token-auth-cert
@@ -26,7 +26,16 @@ CERT_DIR="${OUT}/api"
 CERT_FILE="${CERT_DIR}/api.${CN}"
 
 keyid() {
-  nodejs "${DIR}/_keyid.js" "$1"
+  # NodeJS is installed as `nodejs` in some distros, `node` in others.
+  node_bin="$(command -v nodejs 2>/dev/null || command -v node 2>/dev/null || true)"
+  if [ -z "$node_bin" ]; then
+    echo >&2 'NodeJS is required but not installed. Aborting.'
+    exit 1
+  fi
+  # Recent Node versions complain about `new Buffer()` being deprecated
+  # but the alternative is not available to older versions. Silence the
+  # warning but use the deprecated form to allow greater compatibility.
+  "$node_bin" --no-deprecation "${DIR}/_keyid.js" "$1"
 }
 
 JWT_CRT="${CERT_FILE}.crt"
@@ -37,7 +46,7 @@ mkdir -p "${CERT_DIR}"
 openssl ecparam -name prime256v1 -genkey -noout -out "${JWT_KEY}" 2>/dev/null
 openssl req -x509 -new -nodes -days "${CRT_EXPIRY_DAYS}" -key "${JWT_KEY}" -subj "/CN=api.${CN}" -out "${JWT_CRT}" 2>/dev/null
 openssl ec -in "${JWT_KEY}" -pubout -outform DER -out "${CERT_FILE}.der" 2>/dev/null
-keyid "${CERT_FILE}.der" >"${JWT_KID}" 2>/dev/null
+keyid "${CERT_FILE}.der" >"${JWT_KID}"
 rm "${CERT_FILE}.der"
 
 echo "JWT_CRT=${JWT_CRT//$OUT/\$OUT}"

--- a/scripts/ssl-common.sh
+++ b/scripts/ssl-common.sh
@@ -3,7 +3,7 @@
 
 # ensure we have `easyrsa` available
 if [ -z "${easyrsa_bin-}" ] || [ ! -x "${easyrsa_bin}" ]; then
-    easyrsa_bin="$(command easyrsa 2>/dev/null || true)"
+    easyrsa_bin="$(command -v easyrsa 2>/dev/null || true)"
     if [ -z "${easyrsa_bin}" ]; then
         easyrsa_dir="$(mktemp -dt easyrsa.XXXXXXXX)"
         easyrsa_url="https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.5/EasyRSA-nix-3.0.5.tgz"


### PR DESCRIPTION
NodeJS is installed as `nodejs` in some distros, `node` in others. This ensures we can find either one or fail with a proper error, and also documents that NodeJS is required in the first place.

Fixes: #5
Change-type: patch