### PR TITLE
vagrant: Improve the Vagrant file to make development easier

### DIFF
--- a/.openbalenarc
+++ b/.openbalenarc
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+alias dc="/home/vagrant/openbalena/scripts/compose"
+
+function enter () {
+	if [[ $# -lt 1 ]]; then			
+		echo "Usage: enter <service name> [command]"
+		echo "  "
+		echo "  Runs a [command] in the service specified."
+		echo "  "
+		echo "  command:"
+		echo "    (default) /bin/bash"
+		echo "  "
+		echo "  example:"
+		echo "    enter api          # this will run the command '/bin/bash' in the API service, providing a shell prompt"
+		echo "    enter api uptime   # this will run the command 'uptime' in the API service, and return"
+		return 1
+	fi
+
+
+	service="$1"
+	shift
+	COMMAND=/bin/bash
+	if [[ $# -gt 0 ]]; then
+		COMMAND="$@"
+	fi
+	dc exec ${service} /bin/bash -c "${COMMAND}"
+}
+
+function logs () {
+	if [[ $# -lt 1 ]]; then			
+		echo "Usage: logs <service name> [options]"
+		echo "  "
+		echo "  Shows the logs from journalctl in the service specified."
+		echo "  "
+		echo "  options:"
+		echo "    -f  tail the log stream"
+		echo "    -n  number of lines to take"
+		echo "  "
+		echo "  example:"
+		echo "    logs api -fn100 # this will tail the API log, starting with the last 100 lines"
+		return 1
+	fi
+
+	service="$1"
+	shift
+	enter ${service} journalctl "$@"
+}
+
+cd /home/vagrant/openbalena

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,25 +7,27 @@ Vagrant.require_version '>= 2.0.0'
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.define 'openbalenavm'
-  config.vm.box = 'bento/ubuntu-16.04'
-  config.vm.box_url = 'https://vagrantcloud.com/bento/boxes/ubuntu-16.04/versions/201808.24.0/providers/virtualbox.box'
+  config.vm.define 'openbalena'
+  config.vm.hostname = 'openbalena-vagrant'
+  config.vm.box = 'bento/ubuntu-18.04'
+
+  config.vm.network "public_network",
+    use_dhcp_assigned_default_route: true
 
   config.vm.synced_folder '.', '/vagrant', disabled: true
-  config.vm.synced_folder '.', '/home/vagrant/open-balena'
-  config.vm.network 'public_network', bridge: ENV.fetch('OPENBALENA_BRIDGE', '')
+  config.vm.synced_folder '.', '/home/vagrant/openbalena'
 
   config.ssh.forward_agent = true
 
   config.vm.provision :docker
   config.vm.provision :docker_compose
 
-  # FIXME: remove node
-  config.vm.provision :shell, inline: 'apt-get update && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*'
+  $provision = <<-SCRIPT
+    touch /home/vagrant/.bashrc
+    grep -Fxq 'source /home/vagrant/openbalena/.openbalenarc' /home/vagrant/.bashrc || echo 'source /home/vagrant/openbalena/.openbalenarc' >> /home/vagrant/.bashrc
 
-  config.vm.provision :shell, privileged: false,
-    inline: "cd /home/vagrant/open-balena && ./scripts/quickstart -p -d #{ENV.fetch('OPENBALENA_DOMAIN', 'openbalena.local')}"
+  SCRIPT
 
-  config.vm.provision :shell, privileged: false,
-    inline: "echo 'cd ~/open-balena' >> ~/.bashrc"
+  config.vm.provision :shell, privileged: false, inline: $provision
+
 end


### PR DESCRIPTION
Vagrant machine is based on Ubuntu 18.04 including:
- docker
- docker-compose

Provisions some helper functions to the CLI:
- dc (shortcut to ./scripts/compose)
- enter {service} (opens a terminal in the service's container)
- logs {service} (access the journal of the service)

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>