### PR TITLE
codeowners: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Main repo owners:
+*       @dfunckt @richbayliss


### PR DESCRIPTION
Add a CODEOWNERS file which includes the main repo owners.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>