### PR TITLE
vpn: Remove BALENA_ROOT_CA from the VPN trust chain

### DIFF
--- a/scripts/gen-vpn-certs
+++ b/scripts/gen-vpn-certs
@@ -32,14 +32,9 @@ if [ ! -f $VPN_CA ] || [ ! -f $VPN_CRT ] || [ ! -f $VPN_KEY ] || [ ! -f $VPN_DH 
 
   rm -f $VPN_CA $VPN_CRT $VPN_DH $VPN_KEY
 
-  # generate VPN sub-CA
+  # generate VPN CA
   "$easyrsa_bin" --pki-dir="${VPN_PKI}" init-pki &>/dev/null
-  "$easyrsa_bin" --pki-dir="${VPN_PKI}" --days="${CA_EXPIRY_DAYS}" --req-cn="vpn-ca.${CN}" build-ca nopass subca 2>/dev/null
-
-  # import sub-CA CSR into root PKI, sign, and copy back to vpn PKI
-  "$easyrsa_bin" --pki-dir="${ROOT_PKI}" import-req "${VPN_PKI}/reqs/ca.req" "vpn-ca" 2>/dev/null
-  "$easyrsa_bin" --pki-dir="${ROOT_PKI}" sign-req ca "vpn-ca" 2>/dev/null
-  cp "${ROOT_PKI}/issued/vpn-ca.crt" "${VPN_PKI}/ca.crt"
+  "$easyrsa_bin" --pki-dir="${VPN_PKI}" --days="${CA_EXPIRY_DAYS}" --req-cn="vpn-ca.${CN}" build-ca nopass 2>/dev/null
 
   # generate and sign vpn server certificate
   "$easyrsa_bin" --pki-dir="${VPN_PKI}" --days="${CRT_EXPIRY_DAYS}" build-server-full "vpn.${CN}" nopass 2>/dev/null
@@ -48,8 +43,6 @@ if [ ! -f $VPN_CA ] || [ ! -f $VPN_CRT ] || [ ! -f $VPN_KEY ] || [ ! -f $VPN_DH 
   "$easyrsa_bin" --pki-dir="${VPN_PKI}" --keysize=2048 gen-dh 2>/dev/null
 
   # update indexes and generate CRLs
-  "$easyrsa_bin" --pki-dir="${ROOT_PKI}" update-db 2>/dev/null
   "$easyrsa_bin" --pki-dir="${VPN_PKI}" update-db 2>/dev/null
-  "$easyrsa_bin" --pki-dir="${ROOT_PKI}" gen-crl 2>/dev/null
   "$easyrsa_bin" --pki-dir="${VPN_PKI}" gen-crl 2>/dev/null
 fi

--- a/scripts/make-env
+++ b/scripts/make-env
@@ -12,7 +12,7 @@ usage() {
   echo "  JWT_CRT    Path to Token Auth certificate"
   echo "  JWT_KEY    Path to Token Auth private key"
   echo "  JWT_KID    Path to KeyID for the Token Auth certificate"
-  echo "  VPN_CA     Path to the VPN sub-CA certificate"
+  echo "  VPN_CA     Path to the VPN CA certificate"
   echo "  VPN_CRT    Path to the VPN server certificate"
   echo "  VPN_KEY    Path to the VPN server private key"
   echo "  VPN_DH     Path to the VPN server Diffie Hellman parameters"
@@ -83,7 +83,7 @@ export OPENBALENA_TOKEN_AUTH_PUB=$(b64file "$JWT_CRT")
 export OPENBALENA_TOKEN_AUTH_KEY=$(b64file "$JWT_KEY")
 export OPENBALENA_TOKEN_AUTH_KID=$(b64file "$JWT_KID")
 export OPENBALENA_VPN_CA=$(b64file "$VPN_CA")
-export OPENBALENA_VPN_CA_CHAIN=$(b64file "$ROOT_CA" "$VPN_CA")
+export OPENBALENA_VPN_CA_CHAIN=$(b64file "$VPN_CA")
 export OPENBALENA_VPN_CONFIG=$(b64encode "$VPN_CONFIG")
 export OPENBALENA_VPN_SERVER_CRT=$(b64file "$VPN_CRT")
 export OPENBALENA_VPN_SERVER_KEY=$(b64file "$VPN_KEY")


### PR DESCRIPTION
The VPN CA shouldn't need to be signed by the same CA that the HAproxy service
certificate is signed by. By removing this chain we are able to use a
different CA for the HTTPS services without impacting on the VPN service.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>