### PR TITLE
cert-provider: Update to support ACMEv2 on staging provider

### DIFF
--- a/src/cert-provider/Dockerfile
+++ b/src/cert-provider/Dockerfile
@@ -6,9 +6,11 @@ VOLUME [ "/usr/src/app/certs" ]
 
 RUN apk add --update bash curl git openssl ncurses socat
 
+# from https://github.com/Neilpang/acme.sh/releases/tag/2.8.5
 RUN git clone https://github.com/Neilpang/acme.sh.git && \
     cd acme.sh && \
-    git checkout 08357e3cb0d80c84bdaf3e42ce0e439665387f57 . && \
+    git fetch && git fetch --tags && \
+    git checkout 2.8.5 . && \
     ./acme.sh --install  \
     --cert-home /usr/src/app/certs
 


### PR DESCRIPTION
Acquiring a staging certificiate from LetsEncrypt was failing, so acme.sh was
updated to a later version which added support for using ACMEv2 on the staging
servers.

Changes to the state flow to make access retries infinite as it became apparent
that in some scenarios the certificate acquisition could fail to occur due to
containers taking longer to become accessible.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>