### PR TITLE
Add units to the default timeouts in haproxy.cfg

### DIFF
--- a/src/haproxy/haproxy.cfg
+++ b/src/haproxy/haproxy.cfg
@@ -2,9 +2,9 @@ global
   tune.ssl.default-dh-param 1024
 
 defaults
-  timeout connect 5000
-  timeout client 50000
-  timeout server 50000
+  timeout connect 5s
+  timeout client 50s
+  timeout server 50s
 
 frontend http-in
   mode http


### PR DESCRIPTION

I added units 's' to the default timeouts to make it more readable, since i got confused while reading, specially since others had the suffix seconds and the default timeout is to my knowledge in milliseconds.