### PR TITLE
docs: Add PSA about balenaOS version breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Our [Getting Started][getting-started] guide is the most direct path to getting
 an openBalena installation up and running and successfully deploying your
 application to your device(s).
 
+> **IMPORTANT:** Due to changes in [balenaOS][balena-os], only versions up to and including `2.49.0` are currently supported.
+
 
 ## Documentation
 


### PR DESCRIPTION
Due to a change in the balena-supervisor codebase, only balenaOS
versions <= 2.49.0 are working with open-balena.

This documentation change is a band-aid while we resolve the issue.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>