### PR TITLE
tunnel: Expose tunnel service via TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ application to your device(s).
 The current release of openBalena has the following minimum version requirements:
 
 - balenaOS v2.58.3
-- balena CLI v12.23.4
+- balena CLI v12.38.5
 
 If you are updating from previous openBalena versions, ensure you update the balena
 CLI and reprovision any devices to at least the minimum required versions in order

--- a/compose/mdns.yml
+++ b/compose/mdns.yml
@@ -22,7 +22,7 @@ services:
         # the resin backend (eg. that for BALENA_ROOT_CA if present).
         MDNS_TLD: ${OPENBALENA_HOST_NAME}
         # List of subdomains to advertise. This must include all required hosts.
-        MDNS_SUBDOMAINS: '["api", "db", "registry", "s3", "vpn"]'
+        MDNS_SUBDOMAINS: '["api", "db", "registry", "s3", "tunnel", "vpn"]'
         # The expectation is the DBus socket to use is always at the following location.
         DBUS_SESSION_BUS_ADDRESS: "unix:path=/host/run/dbus/system_bus_socket"
         # Selects the interface used for incoming connections from the wider subnet.

--- a/compose/services.yml
+++ b/compose/services.yml
@@ -168,6 +168,7 @@ services:
           - db.${OPENBALENA_HOST_NAME}
           - s3.${OPENBALENA_HOST_NAME}
           - redis.${OPENBALENA_HOST_NAME}
+          - tunnel.${OPENBALENA_HOST_NAME}
     environment:
       BALENA_HAPROXY_CRT: ${OPENBALENA_ROOT_CRT}
       BALENA_HAPROXY_KEY: ${OPENBALENA_ROOT_KEY}
@@ -183,5 +184,5 @@ services:
       - cert-provider:/usr/src/app/certs
     environment:
       ACTIVE: ${OPENBALENA_ACME_CERT_ENABLED}
-      DOMAINS: "api.${OPENBALENA_HOST_NAME},registry.${OPENBALENA_HOST_NAME},s3.${OPENBALENA_HOST_NAME},vpn.${OPENBALENA_HOST_NAME}"
+      DOMAINS: "api.${OPENBALENA_HOST_NAME},registry.${OPENBALENA_HOST_NAME},s3.${OPENBALENA_HOST_NAME},vpn.${OPENBALENA_HOST_NAME},tunnel.${OPENBALENA_HOST_NAME}"
       OUTPUT_PEM: /certs/open-balena.pem

--- a/scripts/compose
+++ b/scripts/compose
@@ -11,6 +11,10 @@ echo_bold() {
   printf "\\033[1m%s\\033[0m\\n" "$@"
 }
 
+echo_bold_stderr() {
+  printf "\\033[1m%s\\033[0m\\n" "$@" 1>&2
+}
+
 VERSIONS_FILE="${BASE_DIR}/compose/versions"
 if [ ! -f "$VERSIONS_FILE" ]; then
   echo_bold "No service versions defined in ${VERSIONS_FILE}"
@@ -30,6 +34,9 @@ source "${ENV_FILE}"
 if [ ${OPENBALENA_HOST_NAME: -6} == ".local" ]; then
   INCLUDE_MDNS="-f ${BASE_DIR}/compose/mdns.yml"
 fi
+
+# show a warning to update your balena CLI tool...
+echo_bold_stderr "IMPORTANT: Please update your Balena CLI installation to version v12.38.5"
 
 # shellcheck source=/dev/null
 source "${VERSIONS_FILE}"; docker-compose \

--- a/src/haproxy/haproxy.cfg
+++ b/src/haproxy/haproxy.cfg
@@ -34,6 +34,10 @@ frontend ssl-in
   tcp-request content accept if { req.ssl_hello_type 1 }
 
   acl is_ssl req.ssl_ver 2:3.4
+
+  acl host_tunnel req_ssl_sni -i "tunnel.${HAPROXY_HOSTNAME}"
+  use_backend redirect-to-tunnel-in if host_tunnel
+
   use_backend redirect-to-https-in if is_ssl
   use_backend vpn-devices if !is_ssl
 
@@ -41,6 +45,11 @@ backend redirect-to-https-in
   mode tcp
   balance roundrobin
   server localhost 127.0.0.1:444 send-proxy-v2
+
+backend redirect-to-tunnel-in
+  mode tcp
+  balance roundrobin
+  server localhost 127.0.0.1:3129
 
 frontend https-in
   mode http
@@ -117,4 +126,9 @@ backend backend_redis
 listen vpn-tunnel
   mode tcp
   bind *:3128
+  server balena_vpn vpn:3128 check port 3128
+
+listen vpn-tunnel-tls
+  mode tcp
+  bind *:3129 ssl crt /etc/ssl/private/open-balena.pem
   server balena_vpn vpn:3128 check port 3128


### PR DESCRIPTION
In order to support the new CLI and balenaCloud deployment
schemes for the tunnel service, the service is now exposed via
the TLS port 443 on the `tunnel.{domain}` server name.

Change-type: minor
Signed-off-by: Rich Bayliss <rich@balena.io>