### PR TITLE
scripts/compose: Delete Balena CLI version warning

### DIFF
--- a/scripts/compose
+++ b/scripts/compose
@@ -35,9 +35,6 @@ if [ ${OPENBALENA_HOST_NAME: -6} == ".local" ]; then
   INCLUDE_MDNS="-f ${BASE_DIR}/compose/mdns.yml"
 fi
 
-# show a warning to update your balena CLI tool...
-echo_bold_stderr "IMPORTANT: Please update your Balena CLI installation to version v12.38.5"
-
 # shellcheck source=/dev/null
 source "${VERSIONS_FILE}"; docker-compose \
   --project-name 'openbalena' \

--- a/scripts/compose
+++ b/scripts/compose
@@ -11,10 +11,6 @@ echo_bold() {
   printf "\\033[1m%s\\033[0m\\n" "$@"
 }
 
-echo_bold_stderr() {
-  printf "\\033[1m%s\\033[0m\\n" "$@" 1>&2
-}
-
 VERSIONS_FILE="${BASE_DIR}/compose/versions"
 if [ ! -f "$VERSIONS_FILE" ]; then
   echo_bold "No service versions defined in ${VERSIONS_FILE}"


### PR DESCRIPTION
This can be removed completely now — it was added to ensure existing users also update to the latest (at the time) CLI as they updated their open-balena installation.

change-type: patch