### PR TITLE
chore(registry): removed data volume

### DIFF
--- a/compose/services.yml
+++ b/compose/services.yml
@@ -5,7 +5,6 @@ volumes:
   cert-provider: {}
   db: {}
   redis: {}
-  registry: {}
   s3: {}
 
 services:
@@ -65,8 +64,6 @@ services:
     depends_on:
       - s3
       - redis
-    volumes:
-      - registry:/data
     environment:
       API_TOKENAUTH_CRT: ${OPENBALENA_TOKEN_AUTH_PUB}
       BALENA_REGISTRY2_HOST: registry.${OPENBALENA_HOST_NAME}


### PR DESCRIPTION
As discussed in #138, the volume isn't used by openBalena by default, because openBalena provides an S3 service to store the containers. 

To be clear:
The `REGISTRY2_STORAGEPATH` is set to `/data` by default. This is not the `/data` path in the container itself, but the path used by the S3 provider.

Resolves #138 