### PR TITLE
patch: Update differences table with bC

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ improvements and new functionality is planned:
 | Download images from [balena.io][balena-os-website] | Download preconfigured images directly from the dashboard                                                                                                                                                 |
 | No supported remote diagnostics                     | Remote device diagnostics                                                                                                                                                                                 |
 | Supported devices: Raspberry Pi family, the Intel NUC, the NVIDIA Jetson TX2, and the balenaFin | All the devices listed in balena's [reference documentation](https://www.balena.io/docs/reference/hardware/devices/)   |
+| No support for remote host OS updates.              | Remote host OS updates                                                                             |
 
 Additionally, refer back to the [roadmap](#roadmap) above for planned but not yet implemented features.
 


### PR DESCRIPTION
Added a line to the table with the differences between oB and bC about the unavailability of host OS updates in oB. It is mentioned in the Roadmap section, but this makes it more clear and more visible.