### PR TITLE
Update getting-started.md added another hostname

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,6 +35,7 @@ ocsp.mydomain.com
 registry2.mydomain.com
 s3.mydomain.com
 tunnel.mydomain.com
+data.mydomain.com
 ```
 
 Alternatively you may consider adding a single wildcard DNS record `*.mydomain.com`.


### PR DESCRIPTION
When I ran:
 balena whoami --debug
I saw that balena cli was looking for a host named data.

[debug] new argv=[/usr/local/lib/balena-cli/bin/node,/usr/local/lib/balena-cli/bin/run,whoami] length=3 [debug] Deprecation check: 0.04881 days since last npm registry query for next major version release date. [debug] Will not query the registry again until at least 7 days have passed. [debug] Event tracking error: getaddrinfo ENOTFOUND data.balena.sifly.ai
BalenaRequestError: Request error: <html lang="en">

So I added data.mydomain.com to DNS