### PR TITLE
Remove custom_runs_on instruction from flowzone.yml

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -25,15 +25,6 @@ jobs:
     with:
       jobs_timeout_minutes: 60
       cloudflare_website: open-balena
-      custom_runs_on: |
-        [
-          [
-            "self-hosted",
-            "Linux",
-            "X64"
-          ]
-        ]
-
       balena_slugs: |
         balena/open-balena
 


### PR DESCRIPTION
This project has no custom actions to run, and was using the legacy input format for custom jobs that is being deprecated.