### PR TITLE
SSH reliability settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["ipsec-testing"]
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["self-hosted", "X64", "runtime:container", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
   test:
     runs-on:
       group: ipsec-testing
-      labels: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+      labels: ["ipsec-testing"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -839,6 +839,10 @@ jobs:
         aws ec2 wait instance-running --instance-ids "${instance_id}"
         with_backoff aws ec2 wait instance-status-ok --instance-ids "${instance_id}"
 
+        private_ip="$(aws ec2 describe-instances --instance-id "${instance_id}" \
+          | jq -r .Reservations[].Instances[].PrivateIpAddress)"
+        echo "private_ip=${private_ip}" >>"${GITHUB_OUTPUT}"
+
       env:
         ATTEMPTS: 2
         AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
@@ -878,6 +882,10 @@ jobs:
         # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html
         mkdir -p "${HOME}/.ssh/controlmasters"
         cat << EOF > "${HOME}/.ssh/config"
+        host *
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+
         host i-*
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
@@ -986,7 +994,7 @@ jobs:
       env:
         ATTEMPTS: 2
         AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-        DOCKER_HOST: ssh://ubuntu@${{ steps.ubuntu-sut.outputs.instance_id }}:22
+        DOCKER_HOST: ssh://ubuntu@${{ steps.ubuntu-sut.outputs.private_ip }}:22
         COMMIT: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.event.pull_request.head.ref }}
 
     - name: remove balenaCloud SSH key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
   test:
     runs-on:
       group: ipsec-testing
+      labels: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["self-hosted", "X64", "runtime:container", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -798,6 +798,13 @@ jobs:
                 && rm -f "\${tmphosts}" \
                 && getent hosts api.${{ matrix.subdomain }}.${{ matrix.dns_tld }} | grep 127.0.1.1
 
+              service ssh restart
+
+          # https://forums.docker.com/t/docker-compose-through-ssh-failing-and-referring-to-docker-example-com/115165/18
+          - path: /etc/ssh/sshd_config.d/00-cloud-init
+            content: |
+              MaxStartups 100:0:100
+
         # cloud-init runs as root
         # (e.g.) https://cloudinit.readthedocs.io/en/latest/reference/merging.html#example-cloud-config
         runcmd:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,8 @@ env:
 
 jobs:
   test:
-    runs-on: ["ipsec-testing"]
+    runs-on:
+      group: ipsec-testing
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -880,6 +880,11 @@ jobs:
         host i-*
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
+            TCPKeepAlive yes
+            ServerAliveInterval 5
+            ControlPath "${HOME}/.ssh/controlmasters/%r@%h:%p"
+            ControlMaster auto
+            ControlPersist 5m
             ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
         EOF
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["ubuntu-latest"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on:
-      group: ipsec-testing
-      labels: ["ipsec-testing"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["ipsec-testing"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["ipsec-testing"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -994,7 +994,7 @@ jobs:
       env:
         ATTEMPTS: 2
         AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-        DOCKER_HOST: ssh://ubuntu@${{ steps.ubuntu-sut.outputs.private_ip }}:22
+        DOCKER_HOST: ssh://ubuntu@${{ steps.ubuntu-sut.outputs.instance_id }}:22
         COMMIT: ${{ github.event.pull_request.head.sha || github.event.head_commit.id || github.event.pull_request.head.ref }}
 
     - name: remove balenaCloud SSH key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -876,6 +876,7 @@ jobs:
         trap 'log_output' EXIT
 
         # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html
+        mkdir -p "${HOME}/.ssh/controlmasters"
         cat << EOF > "${HOME}/.ssh/config"
         host i-*
             StrictHostKeyChecking no

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -798,6 +798,7 @@ jobs:
                 && rm -f "\${tmphosts}" \
                 && getent hosts api.${{ matrix.subdomain }}.${{ matrix.dns_tld }} | grep 127.0.1.1
 
+              sshd -T
               service ssh restart
 
           # https://forums.docker.com/t/docker-compose-through-ssh-failing-and-referring-to-docker-example-com/115165/18

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["ubuntu-latest"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
> tl;dr `docker-compose` uses so many SSH connections (using `DOCKER_HOST=ssh://...`) that SSHd starts throttling it and breaking CI runs

Thank you for the [hint](https://forums.docker.com/t/docker-compose-through-ssh-failing-and-referring-to-docker-example-com/115165/18?u=ab77):

       MaxStartups
               Specifies the maximum number of concurrent
               unauthenticated connections to the SSH daemon.
               Additional connections will be dropped until
               authentication succeeds or the LoginGraceTime expires for
               a connection.  The default is 10:30:100.

               Alternatively, random early drop can be enabled by
               specifying the three colon separated values
               start:rate:full (e.g. "10:30:60").  sshd(8) will refuse
               connection attempts with a probability of rate/100 (30%)
               if there are currently start (10) unauthenticated
               connections.  The probability increases linearly and all
               connection attempts are refused if the number of
               unauthenticated connections reaches full (60).