### PR TITLE
Remove compose version -- Obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '2.4'
-
 volumes:
   builder-certs-ca: {}
   builder-certs-client: {}


### PR DESCRIPTION
change-type: patch

My git history just became a big mess. I deleted the branch, closed the PR, and just restarted. Here is the previous [PR](https://github.com/balena-io/open-balena/pull/634).

Here is my previous PR message;

Removed the version attribute from the compose file as it is now obsolete. According to Docker, version 2 and version 3 formats have been merged into 1 format. Their suggestion is to remove the attribute. More on this can be found on their [docs](https://docs.docker.com/reference/compose-file/legacy-versions/).

Every time I run `make up` I keep getting the following warning;

```bash
.WARN[0000] /home/balena/open-balena/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```