### PR TITLE
patch: Add missing session token to use ephemeral AWS creds.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -390,6 +390,10 @@ jobs:
           --service cert-manager \
           --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
 
+        with_backoff balena env add AWS_SESSION_TOKEN '${{ env.AWS_SESSION_TOKEN }}' \
+          --service cert-manager \
+          --device '${{ steps.register-test-device.outputs.balena_device_uuid }}'
+
     - name: provision balenaOS ephemeral SUT
       id: balena-sut
       if: matrix.target == 'balena-public-pki'

--- a/src/cert-manager/Dockerfile
+++ b/src/cert-manager/Dockerfile
@@ -1,4 +1,4 @@
 # https://github.com/balena-io/cert-manager
-FROM balena/cert-manager:0.3.1
+FROM balena/cert-manager:0.3.2
 
 COPY *.json /opt/


### PR DESCRIPTION
> we've burned our ACME rate-limits a while ago because of this omission, test success rates should increase after this merges and a certs. backup is stored to S3

Requires: https://github.com/balena-io/cert-manager/pull/49