### PR TITLE
Fix renovate actions regex match for balena-cli version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,10 +102,12 @@ jobs:
 
     # https://github.com/balena-io-examples/setup-balena-action
     - name: Setup balena CLI
-      uses: balena-io-examples/setup-balena-action@main
-      with:
+      uses: balena-io-examples/setup-balena-action@v0.0.6
+      env:
         # renovate: datasource=github-releases depName=balena-io/balena-cli
-        cli-version: v18.2.17
+        BALENA_CLI_VERSION: v18.2.17
+      with:
+        cli-version: ${{ env.BALENA_CLI_VERSION }}
 
     # https://github.com/pdcastro/ssh-uuid#why
     # https://github.com/pdcastro/ssh-uuid#linux-debian-ubuntu-others


### PR DESCRIPTION
The actions regex expects an env var with the _VERSION suffix.

See: https://balena.fibery.io/Work/Project/CLI-native-oclif-build-(no-pkg)-1319