### PR TITLE
patch: VPN won't start otherwise

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ services:
       VPN_HAPROXY_USEPROXYPROTOCOL: 'true'
       VPN_PORT: 443  # also used in balena-io/open-balena-vpn: config/confd/templates/haproxy.cfg.tmpl
       VPN_SERVICE_REGISTER_INTERFACE: eth0  # ensure correct service instance IP is registered with the API
+      PRODUCTION_MODE: 'true'  # always true, as there is no src folder, only build/src
     devices:
       - /dev/net/tun
 


### PR DESCRIPTION
> unblocks https://github.com/balena-io/open-balena/pull/860

```
...
vpn[477]: ++ command -v node
vpn[477]: + command=/usr/local/bin/node
vpn[477]: + args=("--enable-source-maps")
vpn[477]: + entrypoint=build/src/app.js
vpn[477]: + [[ development = \d\e\v\e\l\o\p\m\e\n\t ]]
vpn[477]: + args=('--enable-source-maps' '--import @swc-node/register/esm-register')
vpn[477]: + entrypoint=src/app.ts
vpn[477]: + [[ ! -x /usr/local/bin/node ]]
vpn[477]: + [[ ! -f src/app.ts ]]
vpn[477]: + echo 'ERROR: Invalid command `/usr/local/bin/node src/app.ts`'
vpn[477]: ERROR: Invalid command `/usr/local/bin/node src/app.ts`
vpn[477]: + exit 1
vpn[477]: + cleanup
vpn[477]: + sleep 10s
```

https://balena.fibery.io/Work/Project/Anton-works-1422