### PR TITLE
Removed 'distro:jammy' from the runner specification.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   test:
-    runs-on: ["self-hosted", "X64", "distro:jammy"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
+    runs-on: ["self-hosted", "X64"]  # balenaOS (balena-public-pki) tests require socat v1.7.4
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
Focal runners were removed from the self-hosted fleet so both Noble and Jammy runners should be used.

Change-type: patch