### PR TITLE
patch: Correct DUT digest

### DIFF
--- a/src/test-device/Dockerfile
+++ b/src/test-device/Dockerfile
@@ -1,6 +1,6 @@
 # https://hub.docker.com/r/qemux/qemu
 # https://github.com/qemus/qemu-docker
-FROM ghcr.io/qemus/qemu:7.30@sha256:5e4978c49c059cdb6ed5e7ad5c7bc72d35cb5d3c9960c33ad96486ea457a446d
+FROM ghcr.io/qemus/qemu:7.30@sha256:dcb64905f30a8471ab9ed1966fbccb5439d767652116ef4b115573d24571f11d
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     minicom \


### PR DESCRIPTION
> unblocks pipeline and fixes https://github.com/balena-io/open-balena/pull/1103 

[Auto pinned digest](https://github.com/balena-io/open-balena/commit/bedfe34cc97ad581cba66d5c3a554edcaf41da62) no longer exists (perhaps [rebuilt?](https://github.com/qemus/qemu/pkgs/container/qemu))

https://balena.fibery.io/Work/Project/Capture-data-to-build-the-balena-reliability-pipeline-1422